### PR TITLE
Updated deprecated user mapping

### DIFF
--- a/ui.config/src/main/content/jcr_root/apps/groovyconsole/osgiconfig/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-groovy-console.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/groovyconsole/osgiconfig/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-groovy-console.cfg.json
@@ -1,0 +1,6 @@
+// Configuration created by Apache Sling JCR Installer
+{
+  "user.mapping":[
+    "aem-groovy-console-bundle=[groovy-console-system-user]"
+  ]
+}

--- a/ui.config/src/main/content/jcr_root/apps/groovyconsole/osgiconfig/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-groovy-console.xml
+++ b/ui.config/src/main/content/jcr_root/apps/groovyconsole/osgiconfig/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-groovy-console.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="sling:OsgiConfig"
-    user.mapping="[aem-groovy-console-bundle=groovy-console-system-user]"/>


### PR DESCRIPTION
Deprecated Service User Mapping Format Detected

The deprecated format service:subservice=userId is still in use and needs to be updated.
Please refactor the mapping to use the supported format service:subservice=[userId].

For best practices, please visit Best Practices for Sling Service User Mapping and Service User Definition.
https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/security/best-practices-for-sling-service-user-mapping-and-service-user-definition

Thanks
M